### PR TITLE
Fix issue with using lock names that aren't legal file names.

### DIFF
--- a/src/DistributedLocking.Test/When_Using_Local_File_Locks.cs
+++ b/src/DistributedLocking.Test/When_Using_Local_File_Locks.cs
@@ -49,6 +49,27 @@ namespace Gibraltar.DistributedLocking.Test
         }
 
         [Test]
+        public void Can_Acquire_Lock_With_Unsafe_Name()
+        {
+            var lockScopePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            var lockManager = new DistributedLockManager(new FileLockProvider(lockScopePath));
+
+            try
+            {
+                var unsafeLockName = "\"M<>\"\\a/ry/ h**ad:>> a\\/:*?\"<>| li*tt|le|| la\"mb.?";
+
+                using (var outerLock = lockManager.Lock(this, unsafeLockName, 0))
+                {
+                    Assert.IsNotNull(outerLock, "Unable to acquire the lock");
+                }
+            }
+            finally
+            {
+                Directory.Delete(lockScopePath);
+            }
+        }
+
+        [Test]
         public void Can_Not_Aquire_Same_Lock_On_Another_Thread()
         {
             var lockScopePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());

--- a/src/DistributedLocking.Test/When_Using_Sql_Locks.cs
+++ b/src/DistributedLocking.Test/When_Using_Sql_Locks.cs
@@ -44,6 +44,19 @@ namespace Gibraltar.DistributedLocking.Test
         }
 
         [Test]
+        public void Can_Acquire_Lock_With_Unsafe_Name()
+        {
+            var lockManager = new DistributedLockManager(GetLockProvider(DefaultLockDatabase));
+
+            var unsafeLockName = "\"M<>\"\\a/ry/ h**ad:>> a\\/:*?\"<>| li*tt|le|| la\"mb.?";
+
+            using (var outerLock = lockManager.Lock(this, unsafeLockName, 0))
+            {
+                Assert.IsNotNull(outerLock, "Unable to acquire the lock");
+            }
+        }
+
+        [Test]
         public void Can_Not_Aquire_Same_Lock_On_Another_Thread()
         {
             var lockManager = new DistributedLockManager(GetLockProvider(DefaultLockDatabase));


### PR DESCRIPTION
Previously any attempt to use a lock name that was not a legal file name would fail.  Now we correctly detect and escape invalid file names in locks.