### PR TITLE
Add Cancellation Token Support

### DIFF
--- a/src/DistributedLocking.Test/DistributedLocking.Test.csproj
+++ b/src/DistributedLocking.Test/DistributedLocking.Test.csproj
@@ -6,7 +6,7 @@
 		<AssemblyName>Gibraltar.DistributedLocking.Test</AssemblyName>
 		<Description>Unit tests for the Distributed Locking library</Description>
 		<Copyright>Copyright © 2008-2021 Gibraltar Software, Inc.</Copyright>
-		<Version>1.2.0.0</Version>
+		<Version>1.3.0.0</Version>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\DistributedLocking\DistributedLocking.csproj" />

--- a/src/DistributedLocking.Test/OtherThreadLockHelper.cs
+++ b/src/DistributedLocking.Test/OtherThreadLockHelper.cs
@@ -32,25 +32,25 @@ namespace Gibraltar.DistributedLocking.Test
         private readonly object m_Requester;
         private readonly DistributedLockManager m_LockManager;
         private readonly string m_Name;
-        private readonly int m_Timeout;
+        private readonly CancellationToken m_Cancellation;
         private readonly object m_Lock = new object();
 
         private DistributedLock m_RepositoryLock;
         private bool m_Exiting;
         private bool m_Exited;
 
-        private OtherThreadLockHelper(object requester, DistributedLockManager lockManager, string lockName, int timeout)
+        private OtherThreadLockHelper(object requester, DistributedLockManager lockManager, string lockName, CancellationToken token)
         {
             m_RepositoryLock = null;
             m_Requester = requester;
             m_LockManager = lockManager;
             m_Name = lockName;
-            m_Timeout = timeout;
+            m_Cancellation = token;
         }
 
-        public static OtherThreadLockHelper TryLock(object requester, DistributedLockManager lockManager, string multiprocessLockName, int timeout)
+        public static OtherThreadLockHelper TryLock(object requester, DistributedLockManager lockManager, string multiprocessLockName, CancellationToken token = default)
         {
-            var helper = new OtherThreadLockHelper(requester, lockManager, multiprocessLockName, timeout);
+            var helper = new OtherThreadLockHelper(requester, lockManager, multiprocessLockName, token);
             if (helper.GetMultiprocessLock())
                 return helper;
 
@@ -87,7 +87,7 @@ namespace Gibraltar.DistributedLocking.Test
 
             lock (m_Lock)
             {
-                m_LockManager.TryLock(this, m_Name, m_Timeout, out m_RepositoryLock);
+                m_LockManager.TryLock(this, m_Name, m_Cancellation, out m_RepositoryLock);
 
                 if (m_RepositoryLock != null)
                 {

--- a/src/DistributedLocking.Test/When_Using_Sql_Locks.cs
+++ b/src/DistributedLocking.Test/When_Using_Sql_Locks.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -43,9 +44,47 @@ namespace Gibraltar.DistributedLocking.Test
         {
             var lockManager = new DistributedLockManager(GetLockProvider(DefaultLockDatabase));
 
-            using (var outerLock = lockManager.Lock(this, MultiprocessLockName, 0))
+            using (var outerLock = lockManager.Lock(this, MultiprocessLockName))
             {
                 Assert.IsNotNull(outerLock, "Unable to acquire lock");
+            }
+        }
+
+        [Test]
+        public void Can_Acquire_Lock_With_Integer_Timeout()
+        {
+            var lockManager = new DistributedLockManager(GetLockProvider(DefaultLockDatabase));
+
+            using (var outerLock = lockManager.Lock(this, MultiprocessLockName, 1))
+            {
+                Assert.IsNotNull(outerLock, "Unable to acquire the lock");
+            }
+        }
+
+        [Test]
+        public void Can_Acquire_Lock_With_CancellationToken()
+        {
+            var lockManager = new DistributedLockManager(GetLockProvider(DefaultLockDatabase));
+
+            var tokenSource = new CancellationTokenSource(1000);
+            using (var outerLock = lockManager.Lock(this, MultiprocessLockName, tokenSource.Token))
+            {
+                Assert.IsNotNull(outerLock, "Unable to acquire the lock");
+            }
+        }
+
+        [Test]
+        public void Can_Timeout_Lock_Using_CancellationToken()
+        {
+            var lockManager = new DistributedLockManager(GetLockProvider(DefaultLockDatabase));
+
+            using (var outerLock = lockManager.Lock(this, MultiprocessLockName))
+            {
+                var tokenSource = new CancellationTokenSource(1000);
+                using (var otherLock = OtherThreadLockHelper.TryLock(this, lockManager, MultiprocessLockName, tokenSource.Token))
+                {
+                    Assert.IsNull(otherLock, "Another thread was allowed to get the lock");
+                }
             }
         }
 
@@ -56,7 +95,7 @@ namespace Gibraltar.DistributedLocking.Test
 
             var unsafeLockName = "\"M<>\"\\a/ry/ h**ad:>> a\\/:*?\"<>| li*tt|le|| la\"mb.?";
 
-            using (var outerLock = lockManager.Lock(this, unsafeLockName, 0))
+            using (var outerLock = lockManager.Lock(this, unsafeLockName))
             {
                 Assert.IsNotNull(outerLock, "Unable to acquire the lock");
             }
@@ -67,11 +106,11 @@ namespace Gibraltar.DistributedLocking.Test
         {
             var lockManager = new DistributedLockManager(GetLockProvider(DefaultLockDatabase));
 
-            using (var outerLock = lockManager.Lock(this, MultiprocessLockName, 0))
+            using (var outerLock = lockManager.Lock(this, MultiprocessLockName))
             {
                 Assert.IsNotNull(outerLock, "Unable to acquire outer lock the repository");
 
-                using (var otherLock = OtherThreadLockHelper.TryLock(this, lockManager, MultiprocessLockName, 0))
+                using (var otherLock = OtherThreadLockHelper.TryLock(this, lockManager, MultiprocessLockName))
                 {
                     Assert.IsNull(otherLock, "Another thread was allowed to get the lock");
                 }
@@ -84,16 +123,16 @@ namespace Gibraltar.DistributedLocking.Test
             var lockManager = new DistributedLockManager(GetLockProvider(DefaultLockDatabase));
 
             // First test new re-entrant lock capability.
-            using (var outerLock = lockManager.Lock(this, MultiprocessLockName, 0))
+            using (var outerLock = lockManager.Lock(this, MultiprocessLockName))
             {
                 Assert.IsNotNull(outerLock, "Unable to outer lock the repository");
 
                 // Now check that we can get the same lock on the same thread.
-                using (var middleLock = lockManager.Lock(this, MultiprocessLockName, 0))
+                using (var middleLock = lockManager.Lock(this, MultiprocessLockName))
                 {
                     Assert.IsNotNull(middleLock, "Unable to reenter the repository lock on the same thread");
 
-                    using (var innerLock = lockManager.Lock(this, MultiprocessLockName, 0))
+                    using (var innerLock = lockManager.Lock(this, MultiprocessLockName))
                     {
                         Assert.IsNotNull(innerLock, "Unable to reenter the repository lock on the same thread twice");
                     }
@@ -107,14 +146,14 @@ namespace Gibraltar.DistributedLocking.Test
             var lockManager = new DistributedLockManager(GetLockProvider(DefaultLockDatabase));
 
             // Now test other scenarios while another thread holds the lock.
-            using (var testLock = OtherThreadLockHelper.TryLock(this, lockManager, MultiprocessLockName, 0))
+            using (var testLock = OtherThreadLockHelper.TryLock(this, lockManager, MultiprocessLockName))
             {
                 Assert.IsNotNull(testLock, "Unable to lock the repository");
 
                 //now that I have the test lock, it should fail if I try to get it again.
                 Assert.Catch<LockTimeoutException>(() =>
                         {
-                            using (var failedLock = lockManager.Lock(this, MultiprocessLockName, 0))
+                            using (var failedLock = lockManager.Lock(this, MultiprocessLockName))
                             {
                                 Assert.IsNull(failedLock, "Duplicate lock was allowed.");
                             }
@@ -128,11 +167,11 @@ namespace Gibraltar.DistributedLocking.Test
             var lockManager = new DistributedLockManager(GetLockProvider(DefaultLockDatabase));
 
             // Now test other scenarios while another thread holds the lock.
-            using (var otherLock = OtherThreadLockHelper.TryLock(this, lockManager, MultiprocessLockName + "_alternate", 0))
+            using (var otherLock = OtherThreadLockHelper.TryLock(this, lockManager, MultiprocessLockName + "_alternate"))
             {
                 Assert.IsNotNull(otherLock, "Unable to establish first lock in scope.");
 
-                using (var testLock = lockManager.Lock(this, MultiprocessLockName, 0))
+                using (var testLock = lockManager.Lock(this, MultiprocessLockName))
                 {
                     Assert.IsNotNull(testLock, "Unable to establish second lock in scope.");
                 }
@@ -145,17 +184,17 @@ namespace Gibraltar.DistributedLocking.Test
             var firstLockManager = new DistributedLockManager(GetLockProvider(DefaultLockDatabase));
 
             // Now test other scenarios while another thread holds the lock.
-            using (var testLock = firstLockManager.Lock(this, MultiprocessLockName, 0))
+            using (var testLock = firstLockManager.Lock(this, MultiprocessLockName))
             {
                 Assert.IsNotNull(testLock, "Unable to establish lock on first scope");
 
                 var secondLockManager = new DistributedLockManager(GetLockProvider(SecondLockDatabase));
-                using (var secondTestLock = secondLockManager.Lock(this, MultiprocessLockName, 0))
+                using (var secondTestLock = secondLockManager.Lock(this, MultiprocessLockName))
                 {
                     Assert.IsNotNull(secondTestLock, "Unable to establish lock on second scope.");
 
                     var thirdLockManager = new DistributedLockManager(GetLockProvider(ThirdLockDatabase));
-                    using (var thirdTestLock = thirdLockManager.Lock(this, MultiprocessLockName, 0))
+                    using (var thirdTestLock = thirdLockManager.Lock(this, MultiprocessLockName))
                     {
                         Assert.IsNotNull(thirdTestLock, "Unable to establish lock on third scope.");
                     }
@@ -168,7 +207,7 @@ namespace Gibraltar.DistributedLocking.Test
         {
             var lockManager = new DistributedLockManager(GetLockProvider(DefaultLockDatabase));
 
-            using (var testLock = OtherThreadLockHelper.TryLock(this, lockManager, MultiprocessLockName, 0))
+            using (var testLock = OtherThreadLockHelper.TryLock(this, lockManager, MultiprocessLockName))
             {
                 Assert.IsNotNull(testLock, "Unable to lock the repository");
 
@@ -199,7 +238,7 @@ namespace Gibraltar.DistributedLocking.Test
 
             for (var curIteration = 0; curIteration < lockIterations; curIteration++)
             {
-                using (var outerLock = lockManager.Lock(this, MultiprocessLockName, 0))
+                using (var outerLock = lockManager.Lock(this, MultiprocessLockName))
                 {
                     Assert.IsNotNull(outerLock, "Unable to acquire lock on iteration {0:N0}", curIteration);
                 }
@@ -217,7 +256,7 @@ namespace Gibraltar.DistributedLocking.Test
             {
                 try
                 {
-                    var outerLock = lockManager.Lock(this, MultiprocessLockName, 0);
+                    var outerLock = lockManager.Lock(this, MultiprocessLockName);
 
                     try
                     {

--- a/src/DistributedLocking.Test/When_Using_Sql_Locks.cs
+++ b/src/DistributedLocking.Test/When_Using_Sql_Locks.cs
@@ -28,10 +28,10 @@ namespace Gibraltar.DistributedLocking.Test
     public class When_Using_Sql_Locks
     {
 #if NETCOREAPP
-        private const string ConnectionStringTemplate = "Data Source=tcp:{0};Initial Catalog={1};Integrated Security=False;MultipleActiveResultSets=True;";
+        private const string ConnectionStringTemplate = "Data Source=tcp:{0};Initial Catalog={1};Integrated Security=False;MultipleActiveResultSets=True;User Id=sa;Password=f4rd+GM%";
 #else
         private const string ConnectionStringTemplate = "Data Source={0};Initial Catalog={1};Integrated Security=False;MultipleActiveResultSets=True;" +
-                                                        "Network Library=dbmssocn;";
+                                                        "Network Library=dbmssocn;User Id=sa;Password=f4rd+GM%";
 #endif
         private const string MultiprocessLockName = "LockRepository";
         private const string DefaultLockDatabase = "lock_test";

--- a/src/DistributedLocking/DistributedLocking.csproj
+++ b/src/DistributedLocking/DistributedLocking.csproj
@@ -22,7 +22,7 @@
 		<PackageIcon>loupe-192x192.png</PackageIcon>
 		<PackageIconUrl />
 		<Product>Gibraltar Software Distributed Locking</Product>
-		<Version>1.2.0.0</Version>
+		<Version>1.3.0.0</Version>
 		<Description>Easily manage locks between processes and computers using this re-entrant locking library.  Uses a common file system, network share, or SQL Database to let you create arbitrary locks in your distributed application with a simple syntax.</Description>
 		<Copyright>Copyright © 2008-2021 Gibraltar Software, Inc.</Copyright>
 	</PropertyGroup>

--- a/src/DistributedLocking/Internal/DistributedLockProxy.cs
+++ b/src/DistributedLocking/Internal/DistributedLockProxy.cs
@@ -248,7 +248,7 @@ namespace Gibraltar.DistributedLocking.Internal
             var waitForLock = currentRequest.WaitForLock;
             var validLock = false;
 
-            while (waitForLock == false || currentRequest.IsExpired)
+            while (waitForLock == false || currentRequest.IsExpired == false)
             {
                 if (DateTimeOffset.Now >= _minTimeNextTurn) // Make sure we aren't in a back-off delay.
                 {

--- a/src/DistributedLocking/Internal/DistributedLockProxy.cs
+++ b/src/DistributedLocking/Internal/DistributedLockProxy.cs
@@ -165,7 +165,7 @@ namespace Gibraltar.DistributedLocking.Internal
             if (ourTurn == false)
             {
                 // It's not our turn yet, we need to wait our turn.  Are we willing to wait?
-                if (lockRequest.WaitForLock && lockRequest.WaitTimeout > DateTimeOffset.Now)
+                if (lockRequest.WaitForLock && lockRequest.IsExpired == false)
                     ourTurn = lockRequest.AwaitTurnOrTimeout();
 
                 // Still not our turn?
@@ -246,10 +246,9 @@ namespace Gibraltar.DistributedLocking.Internal
         private bool TryGetLock(DistributedLock currentRequest)
         {
             var waitForLock = currentRequest.WaitForLock;
-            var lockTimeout = currentRequest.WaitTimeout;
             var validLock = false;
 
-            while (waitForLock == false || DateTimeOffset.Now < lockTimeout)
+            while (waitForLock == false || currentRequest.IsExpired)
             {
                 if (DateTimeOffset.Now >= _minTimeNextTurn) // Make sure we aren't in a back-off delay.
                 {

--- a/src/DistributedLocking/LockTimeoutException.cs
+++ b/src/DistributedLocking/LockTimeoutException.cs
@@ -32,10 +32,10 @@ namespace Gibraltar.DistributedLocking
         /// </summary>
         /// <param name="providerName">The name of the distributed lock provider</param>
         /// <param name="lockName">The name of the lock to get (locks are a combination of index and this name)</param>
-        /// <param name="timeoutSeconds">The maximum number of seconds to wait on the lock before giving up.</param>
+        /// <param name="timeout">The duration the lock waited to timeout.</param>
         /// <param name="message">The error message string.</param>
-        public LockTimeoutException(string providerName, string lockName, int timeoutSeconds, string message)
-            :this(providerName, lockName, timeoutSeconds, message, null)
+        public LockTimeoutException(string providerName, string lockName, TimeSpan timeout, string message)
+            :this(providerName, lockName, timeout, message, null)
         {
         }
 
@@ -44,16 +44,17 @@ namespace Gibraltar.DistributedLocking
         /// </summary>
         /// <param name="providerName">The name of the distributed lock provider</param>
         /// <param name="lockName">The name of the lock to get (locks are a combination of index and this name)</param>
-        /// <param name="timeoutSeconds">The maximum number of seconds to wait on the lock before giving up.</param>
+        /// <param name="timeout">The duration the lock waited to timeout.</param>
         /// <param name="message">The error message string.</param>
         /// <param name="innerException">The exception that is the cause of the current exception, or a
         /// null reference if no inner exception is specified.</param>
-        public LockTimeoutException(string providerName, string lockName, int timeoutSeconds, string message, Exception innerException)
+        public LockTimeoutException(string providerName, string lockName, TimeSpan timeout, string message, Exception innerException)
             : base(message, innerException)
         {
             ProviderName = providerName;
             LockName = lockName;
-            TimeoutSeconds = timeoutSeconds;
+            Timeout = timeout;
+            TimeoutSeconds = Convert.ToInt32(Timeout.TotalSeconds);
 
             if (Debugger.IsAttached)
                 Debugger.Break();
@@ -68,6 +69,11 @@ namespace Gibraltar.DistributedLocking
         /// The number of seconds the lock waited before it timed out.
         /// </summary>
         public int TimeoutSeconds { get; }
+
+        /// <summary>
+        /// The duration the lock waited before it timed out.
+        /// </summary>
+        public TimeSpan Timeout { get; }
 
         /// <summary>
         /// The name of the lock being acquired


### PR DESCRIPTION
It would be super convenient to be able to use cancellation tokens so we can go into blocking waits for a lock but bail if our caller cancels, instead of being stuck with just using a timeout and manually polling a lock.